### PR TITLE
Updated to allow for a parent element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-float-anchor",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "React component for positioning an element aligned to another",
   "main": "js/index.js",
   "sideEffects": false,

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export type {Options} from 'contain-by-screen';
 
 export type Props = {
   anchor: (anchorRef: React$Ref<any>) => React$Node;
+  parentElement?: ?HTMLElement;
   float?: ?React$Node;
   options?: ?Options;
   zIndex?: ?number|string;
@@ -43,6 +44,7 @@ export type Props = {
 export default class FloatAnchor extends React.Component<Props> {
   static propTypes = {
     anchor: PropTypes.func.isRequired,
+    parentElement: PropTypes.any,
     float: PropTypes.node,
     options: PropTypes.object,
     zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -196,6 +198,7 @@ export default class FloatAnchor extends React.Component<Props> {
   }
 
   _mountPortalEl = () => {
+    const { parentElement } = this.props;
     const portalEl = this._portalEl;
     /*:: if (!portalEl) throw new Error(); */
     if (portalEl.parentElement) {
@@ -206,7 +209,7 @@ export default class FloatAnchor extends React.Component<Props> {
     if (!anchorRef) throw new Error('ReactFloatAnchor missing anchorRef element');
     (portalEl: any).rfaAnchor = anchorRef;
 
-    const target = document.body || document.documentElement;
+    const target = parentElement ? parentElement : document.body || document.documentElement;
     /*:: if (!target) throw new Error(); */
     target.appendChild(portalEl);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,7 @@
 
 import sinon from 'sinon';
 const sinonTest = require('sinon-test')(sinon);
-import React from 'react';
+import React, {useState} from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
 import renderer from 'react-test-renderer';


### PR DESCRIPTION
So the list was appearing outside my actual root element.  This caused some serious problems with styling and control of the item.  So I've updated it to now accept a parentElement that will be used as the root instead of just assuming the document.

I couldn't get the tests updated, maybe you know how I would add a test to this.